### PR TITLE
Fix min/max in DataAxis

### DIFF
--- a/shade_ms/data_mappers.py
+++ b/shade_ms/data_mappers.py
@@ -335,7 +335,7 @@ class DataAxis(object):
             else:
                 min1, max1 = coldata.data.min(), coldata.data.max()
             self.minmax = min(self.minmax[0], min1) if self.minmax[0] is not None else min1, \
-                          min(self.minmax[1], max1) if self.minmax[1] is not None else max1
+                          max(self.minmax[1], max1) if self.minmax[1] is not None else max1
         # scalar is just a scalar
         if np.isscalar(coldata):
             coldata = da.array(coldata)

--- a/shade_ms/tests/test_data_mappers.py
+++ b/shade_ms/tests/test_data_mappers.py
@@ -1,0 +1,18 @@
+import dask.array as da
+import numpy as np
+import xarray
+
+from shade_ms.data_mappers import DataAxis
+
+
+def _spw(freqs):
+    return xarray.DataArray(da.from_array(np.array(freqs), chunks=len(freqs)), dims=("chan",))
+
+
+def test_const_axis_minmax_spans_all_groups():
+    """A constant axis accumulates its range over every group, not just the narrowest one."""
+    axis = DataAxis(None, "FREQ", False, ms=None, label="FREQ")
+    for freqs in ([1e9, 2e9], [3e9, 4e9]):   # two SPWs, as ddids of differing coverage
+        axis.get_value(None, None, dict(freqs=_spw(freqs)),
+                       flag=None, flag_row=None, chanslice=slice(None))
+    assert axis.minmax == (1e9, 4e9)


### PR DESCRIPTION
Hey all,

This MR fixes what I think is a bug in `DataAxis.get_value` where the on-the-fly minmax for a constant
axis (FREQ, CHAN, WAVEL, CORR) accumulated its upper bound with `min` instead of
`max`:

    self.minmax = min(self.minmax[0], min1) if self.minmax[0] is not None else min1, \
                  min(self.minmax[1], max1) if self.minmax[1] is not None else max1

`get_value` is called once per group, folding that group's range into the
axis-wide one. The lower bound was right; the upper bound converged on the
*smallest* per-group maximum instead of the largest.

I think this only bites with two or more groups over the same axis -- several
SPWs/DDIDs, or fields/scans in `--iter-*` -- since the first call takes the
`is not None` branch and is a plain assignment. So with a single SPW it's
invisible, which is presumably why it has survived.

Symptom would be a FREQ/CHAN axis whose top is the narrowest group's top,
silently clipping everything above it out of the plot -- no error, just missing
data. And since the result is persisted to `<ms>-minmax-cache.json`, a wrong
upper bound outlives the run that computed it.

Also adds a test to cover the issue: it drives `get_value` over two SPWs of
differing frequency coverage and asserts the resulting range spans both. It
fails on the current `min` and passes with `max`.
